### PR TITLE
Added flexibility to printFile

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,22 @@ recently this addon supports the functions below:
 
 (have to be more useful)
 
-## note
+## Notes
 - not available for windows.
 - required adding libcups.2.dylib (see Screen Shot 2012-03-05 17.35.48.png)
 
-## forum
+## Installation Instructions
+1. Download and install [gutenprint](http://gimp-print.sourceforge.net/MacOSX.php).
+	- You can use either the DMG file or compile from source.
+2. Add the libcups.2.dylib to your project. 
+	- In the Projects window click on your Target.
+	- Go to the "Build Phases" tab.
+	- Click the "+" button underneath "Link Binary With Libraries"
+	- In the ensuing window prompt search for "libcups.2.dylib". Select that and choose add. **You do not need any of the other dylibs listed**.
+3. Include the addon in your openFrameworks project.
+4. Look to the included example file for how to implement ofxCUPs in your project.	
+
+## Original Forum Post
 - http://forum.openframeworks.cc/index.php/topic,1474.0.html
 
 ## CUPS api documentation

--- a/example/src/testApp.cpp
+++ b/example/src/testApp.cpp
@@ -4,8 +4,6 @@
 #pragma setup
 void testApp::setup()
 {
-
-    
     ofSetFrameRate(1);
     
     
@@ -13,12 +11,12 @@ void testApp::setup()
     printer.listPrinters();
     
     // set printer name which you want to use...
-    printer.setPrinterName("EPSON_E_600");
+    printer.setPrinterName("ENTER_YOUR_PRINTER_NAME_HERE");
     
     // print options....... see also http://www.cups.org/documentation.php/doc-1.5/options.html
-    // or, set printer default option from http://localhost:631/printers/ 
+    // or, set printer default option from http://localhost:631/printers/
     printer.addOption("media", "KG.Maximum");
-//    printer.addOption("resolution", "300dpi");
+//    printer.addOption("resolution", "300dpi"); // one particularly useful option to know about.
         
     // if necessary.......
     printer.setJobTitle("ofxCUPS Test");
@@ -81,12 +79,13 @@ void testApp::draw()
     
     
     ofSetColor(255, 255, 255);
-    ofDrawBitmapString("Press [p] to print test image...", 20, 20);
-    ofDrawBitmapString("Press [c] to check state of active jobs... (the results will appear on console)",   20, 40);
-    ofDrawBitmapString("Press [a] to clear all jobs... (the results will appear on console)",   20, 60);
-    ofDrawBitmapString("printerName:  " + printer.getPrinterName(), 20, 100);
-    ofDrawBitmapString("printerState: " + printerState,             20, 120);
-    ofDrawBitmapString("printerInfo:  " + printerInfo,              20, 140);
+    ofDrawBitmapString("Press [p] to print test-image.jpg from your data directory.", 20, 20);
+    ofDrawBitmapString("Press [o] to choose a jpg or png and print that.", 20, 40);
+    ofDrawBitmapString("Press [c] to check state of active jobs... (the results will appear on console)",   20, 60);
+    ofDrawBitmapString("Press [a] to clear all jobs... (the results will appear on console)",   20, 80);
+    ofDrawBitmapString("printerName:  " + printer.getPrinterName(), 20, 120);
+    ofDrawBitmapString("printerState: " + printerState,             20, 140);
+    ofDrawBitmapString("printerInfo:  " + printerInfo,              20, 160);
 }
 
 
@@ -97,7 +96,25 @@ void testApp::keyPressed(int key)
     
     if (key == 'p')
     {
-        printer.printImage("testimge.png");
+        // prints from your app's data directory.
+        printer.printImage("test-image.png");
+    }
+    else if(key == 'o')
+    {
+        ofFileDialogResult fileDialogResult = ofSystemLoadDialog("Select a valid image file");
+
+        if(fileDialogResult.bSuccess) {
+            // ghetto way of testing the mime type
+            ofImage validImageTest;
+            if(validImageTest.loadImage(fileDialogResult.getPath())) {
+                // by passing the true boolean, the printer will assume an absolute path to the image to print.
+                printer.printImage(fileDialogResult.getPath(),true);
+            }
+            else {
+                ofLog(OF_LOG_ERROR, "Please select a valid image.");
+            }
+        }
+        
     }
     if (key == 'a')
     {

--- a/ofxCUPS/src/ofxCUPS.cpp
+++ b/ofxCUPS/src/ofxCUPS.cpp
@@ -29,16 +29,23 @@ void ofxCUPS::listPrinters()
     cout << "----------------------------------------" << endl;
 }
 
+void ofxCUPS::printImage(string filename) {
+    printImage(filename,false);
+}
 
-void ofxCUPS::printImage(string filename)
-{
-    int num_options = 0;  
+void ofxCUPS::printImage(string filename, bool isAbsolutePath) {
+    int num_options = 0;
     cups_option_t *options = NULL;  
-    
-    string path = "../../../data/";
-    string currentFile = filename;
-    string printFile = path + currentFile;
-    //optionen = "media=DS_PC_size"; //ds40  
+
+    string printFile;
+    if(isAbsolutePath) {
+        printFile = filename;
+    }
+    else {
+        printFile = ofToDataPath("./",true) + filename;
+    }
+
+    //optionen = "media=DS_PC_size"; //ds40
     
     //num_options = cupsParseOptions(optionen.c_str(), num_options, &options);  
     

--- a/ofxCUPS/src/ofxCUPS.h
+++ b/ofxCUPS/src/ofxCUPS.h
@@ -15,6 +15,8 @@ public:
     
     void listPrinters();
     void printImage(string filename);
+    void printImage(string filename,bool isAbsolutePath);
+
     void updatePrinterInfo();
     void clearAllJobs();
     void checkActiveJobStatus();


### PR DESCRIPTION
I made a minor tweak to this addon so it's easier to target files to print, whether they're in your data/ directory or not.

I also added in some installation instructions. The forum post wasn't clear whether you needed to configure and make CUPs or gutenprint. If one were to try to configure and make CUPs and the build failed bad things could happen to their system. Hopefully the README will help clarify what people need to install and what they don't.

Out of curiosity is it possible to just send raw data to CUPS? Similarly is it possible to specify other sorts of file formats, like docs or rtfs? While it's pretty reasonable to assume anyone using openFrameworks + ofxCUPS is probably printing something visual in nature it'd be nice to create flexibility for other kinds of file formats.
